### PR TITLE
support arrays and slices as input params to 'models::wls::Wls::new'

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,35 @@ weighted linear regression in pure Rust w/o any 3d party dependencies or framewo
 
 ### How-to
 
+#### Fit linear regression using weights
+
 ```rust
-use wls_rs::asserts::assert::assert_almost_equal;
-use wls_rs::models::wls::Wls;
-
 fn main() {
-    let x_points = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
-    let y_points = vec![1.0, 3.0, 4.0, 5.0, 2.0, 3.0, 4.0];
-    let weights = vec![10.0, 1.0, 3.0, 8.0, 14.0, 21.0, 13.0];
+    let x_points = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
+    let y_points = [1.0, 3.0, 4.0, 5.0, 2.0, 3.0, 4.0];
+    let weights = [10.0, 1.0, 3.0, 8.0, 14.0, 21.0, 13.0];
 
-    let wls = Wls::new(x_points, y_points, Some(weights));
+    let wls = Wls::new(&x_points, &y_points, &weights);
     let point = wls.fit_linear_regression().unwrap();
 
     assert_almost_equal(1.410964913, point.get_intercept(), 1.0e-6);
     assert_almost_equal(0.321271930, point.get_slope(), 1.0e-6);
+}
+```
+
+#### Fit linear regression using stable weights
+
+```rust
+fn main() {
+    let x_points = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
+    let y_points = vec![1.0, 3.0, 4.0, 5.0, 2.0, 3.0, 4.0];
+    let stable_weights = vec![1.0; x_points.len()];
+
+    let wls = Wls::new(&x_points, &y_points, &stable_weights);
+    let point = wls.fit_linear_regression().unwrap();
+
+    assert_almost_equal(2.14285714, point.get_intercept(), 1.0e-6);
+    assert_eq!(0.25, point.get_slope());
 }
 ```
 

--- a/examples/examples.rs
+++ b/examples/examples.rs
@@ -2,13 +2,24 @@ use wls_rs::asserts::assert::assert_almost_equal;
 use wls_rs::models::wls::Wls;
 
 fn main() {
-    let x_points = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
-    let y_points = vec![1.0, 3.0, 4.0, 5.0, 2.0, 3.0, 4.0];
-    let weights = vec![10.0, 1.0, 3.0, 8.0, 14.0, 21.0, 13.0];
+    let x_points = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
+    let y_points = [1.0, 3.0, 4.0, 5.0, 2.0, 3.0, 4.0];
+    let weights = [10.0, 1.0, 3.0, 8.0, 14.0, 21.0, 13.0];
 
-    let wls = Wls::new(x_points, y_points, Some(weights));
+    let wls = Wls::new(&x_points, &y_points, &weights);
     let point = wls.fit_linear_regression().unwrap();
 
     assert_almost_equal(1.410964913, point.get_intercept(), 1.0e-6);
     assert_almost_equal(0.321271930, point.get_slope(), 1.0e-6);
+
+    // fit linear regression using stable weights
+    let x_points = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
+    let y_points = vec![1.0, 3.0, 4.0, 5.0, 2.0, 3.0, 4.0];
+    let stable_weights = vec![1.0; x_points.len()];
+
+    let wls = Wls::new(&x_points, &y_points, &stable_weights);
+    let point = wls.fit_linear_regression().unwrap();
+
+    assert_almost_equal(2.14285714, point.get_intercept(), 1.0e-6);
+    assert_eq!(0.25, point.get_slope());
 }

--- a/src/models/wls.rs
+++ b/src/models/wls.rs
@@ -1,34 +1,22 @@
 use crate::asserts::assert::{assert_have_same_size, assert_have_size_greater_than_two};
 use crate::models::point::Point;
 
-pub struct Wls {
-    x_points: Vec<f64>,
-    y_points: Vec<f64>,
-    weights: Vec<f64>,
+pub struct Wls<'a> {
+    x_points: &'a [f64],
+    y_points: &'a [f64],
+    weights: &'a [f64],
 }
 
-fn populate_weights(capacity: &[f64], value: f64) -> Vec<f64> {
-    vec![value; capacity.len()]
-}
+impl<'a> Wls<'a> {
+    pub fn new(x_points: &'a [f64], y_points: &'a [f64], weights: &'a [f64]) -> Self {
+        assert_have_size_greater_than_two(x_points);
+        assert_have_same_size(x_points, y_points);
+        assert_have_same_size(x_points, weights);
 
-impl Wls {
-    pub fn new(x_points: Vec<f64>, y_points: Vec<f64>, weights: Option<Vec<f64>>) -> Self {
-        let mut weights_normalized: Vec<f64> = vec![];
-
-        assert_have_same_size(&x_points, &y_points);
-        if let Some(weights) = weights {
-            weights_normalized = weights;
-            assert_have_same_size(&x_points, &weights_normalized);
-        }
-        assert_have_size_greater_than_two(&x_points);
-
-        if weights_normalized.is_empty() {
-            weights_normalized = populate_weights(&x_points, 1.0);
-        }
         Self {
             x_points,
             y_points,
-            weights: weights_normalized,
+            weights,
         }
     }
 
@@ -78,11 +66,15 @@ mod tests {
     use crate::asserts::assert::{assert_almost_equal, assert_true};
     use crate::models::point::Point;
 
+    fn populate_weights(capacity: &[f64], value: f64) -> Vec<f64> {
+        vec![value; capacity.len()]
+    }
+
     pub fn assert_model_can_be_fit(wls: &Wls) -> Point {
-        return match wls.fit_linear_regression() {
+        match wls.fit_linear_regression() {
             Some(point) => point,
             None => panic!("can't fit linear regression"),
-        };
+        }
     }
 
     #[test]
@@ -91,7 +83,7 @@ mod tests {
         let y_points = vec![1.0, 3.0, 4.0, 5.0, 2.0, 3.0, 4.0];
         let weights = vec![1.0, 2.0, 3.0, 1.0, 8.0, 1.0, 5.0];
 
-        let wls = Wls::new(x_points, y_points, Some(weights));
+        let wls = Wls::new(&x_points, &y_points, &weights);
 
         let point: Point = assert_model_can_be_fit(&wls);
         assert_almost_equal(2.288793, point.get_intercept(), 1.0e-6);
@@ -102,8 +94,9 @@ mod tests {
     fn test_wls_model_with_stable_weights_ok() {
         let x_points = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
         let y_points = vec![1.0, 3.0, 4.0, 5.0, 2.0, 3.0, 4.0];
+        let stable_weights = populate_weights(&x_points, 1.0);
 
-        let wls = Wls::new(x_points, y_points, None);
+        let wls = Wls::new(&x_points, &y_points, &stable_weights);
 
         let point: Point = assert_model_can_be_fit(&wls);
         assert_almost_equal(2.14285714, point.get_intercept(), 1.0e-6);
@@ -114,8 +107,9 @@ mod tests {
     fn test_horizontal_line_ok() {
         let x_points = vec![0.0, 1.0];
         let y_points = vec![10.0, 10.0];
+        let stable_weights = populate_weights(&x_points, 1.0);
 
-        let wls = Wls::new(x_points, y_points, None);
+        let wls = Wls::new(&x_points, &y_points, &stable_weights);
 
         let point: Point = assert_model_can_be_fit(&wls);
         assert_eq!(10.0, point.get_intercept());
@@ -126,8 +120,9 @@ mod tests {
     fn test_vertical_line_ok() {
         let x_points = vec![1.0, 1.0];
         let y_points = vec![0.0, 1.0];
+        let stable_weights = populate_weights(&x_points, 1.0);
 
-        let wls = Wls::new(x_points, y_points, None);
+        let wls = Wls::new(&x_points, &y_points, &stable_weights);
         assert_true(wls.fit_linear_regression().is_none());
     }
 
@@ -135,8 +130,9 @@ mod tests {
     fn test_run_uphill_ok() {
         let x_points = vec![0.0, 1.0];
         let y_points = vec![0.0, 1.0];
+        let stable_weights = populate_weights(&x_points, 1.0);
 
-        let wls = Wls::new(x_points, y_points, None);
+        let wls = Wls::new(&x_points, &y_points, &stable_weights);
 
         let point: Point = assert_model_can_be_fit(&wls);
         assert_eq!(0.0, point.get_intercept());
@@ -147,8 +143,9 @@ mod tests {
     fn test_run_downhill_ok() {
         let x_points = vec![1.0, 0.0];
         let y_points = vec![0.0, 1.0];
+        let stable_weights = populate_weights(&x_points, 1.0);
 
-        let wls = Wls::new(x_points, y_points, None);
+        let wls = Wls::new(&x_points, &y_points, &stable_weights);
 
         let point: Point = assert_model_can_be_fit(&wls);
         assert_eq!(1.0, point.get_intercept());


### PR DESCRIPTION
- support arrays and slices as input params to 'models::wls::Wls::new'
- don't move ownership of input containers
